### PR TITLE
Fix LISTEN.moe brand

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <div align="center">ListenTUI</div>
 
-<div align="center">A listen.moe TUI application</div>
+<div align="center">A LISTEN.moe TUI application</div>
 
 ![image of application](.assets/main.png)
 
@@ -105,8 +105,8 @@ Base on your distro, this is located at:
 
 #### System
 
-- `username`: username used to log into listen.moe
-- `password`: password used to log into listen.moe
+- `username`: username used to log into LISTEN.moe
+- `password`: password used to log into LISTEN.moe
 - `instance_lock`: limit the running instance to one
 
 #### Keybind
@@ -132,7 +132,7 @@ Tip: You can use identifiers such as `${SPACE}`, more at [Window](https://github
 - `enable_rpc`: enable rich presence integration
 - `default_placeholder`: placeholder for when text field falls below the two character limit specified by discord
 - `use_fallback`: use a fallback image if there isnt one
-- `fallback`: the fallback image, has to be a link that discord can access (alternatively, use "fallback2" for [listen.moe](https://listen.moe/_nuxt/img/logo-square-64.248c1f3.png) icon)
+- `fallback`: the fallback image, has to be a link that discord can access (alternatively, use "fallback2" for [LISTEN.moe](https://listen.moe/_nuxt/img/logo-square-64.248c1f3.png) icon)
 - `use_artist`: use the artist image instead if no album image is found
 
 #### Player
@@ -145,7 +145,7 @@ Tip: You can use identifiers such as `${SPACE}`, more at [Window](https://github
 
 ![image of terminal](.assets/terminal.png)
 
-The terminal allows user to query different information through listen.moe
+The terminal allows user to query different information through LISTEN.moe
 
 ## Usage
 

--- a/listentui/__main__.py
+++ b/listentui/__main__.py
@@ -15,7 +15,7 @@ from listentui.config import Config
 from listentui.log import Logger
 from listentui.main import Main
 
-parser = ArgumentParser(prog="Listen.tui", description="A tui for listen.moe")
+parser = ArgumentParser(prog="Listen.tui", description="A tui for LISTEN.moe")
 parser.add_argument("--config", "-c",
                     dest="config",
                     action="store",

--- a/listentui/listen/types.py
+++ b/listentui/listen/types.py
@@ -455,7 +455,7 @@ class ListenWsData:
     @classmethod
     def from_data(cls: Type[Self], data: dict[str, Any]) -> Self:
         """
-        A dataclass representation of listen.moe websocket data
+        A dataclass representation of LISTEN.moe websocket data
 
         Args:
             data `dict`: The websocket data

--- a/listentui/main.py
+++ b/listentui/main.py
@@ -925,7 +925,7 @@ class HeadingPanel(ConsoleRenderable):
         pass
 
     def __rich_console__(self, _: Console, __: ConsoleOptions) -> RenderResult:
-        yield Panel(Text(f'Listen.Moe (󰋋 {self.listener})', justify='center'))
+        yield Panel(Text(f'LISTEN.moe (󰋋 {self.listener})', justify='center'))
 
     def update(self, listener: int) -> None:
         self.listener = listener

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "listentui"
 version = "1.1.0"
-description = "a listen.moe tui application"
+description = "a LISTEN.moe tui application"
 authors = ["kwevin <kwevinnotdev@gmail.com>"]
 readme = "README.md"
 exclude = ["utils/build.py"]


### PR DESCRIPTION
This PR changes the occurrences of `Listen.Moe` and variants to the branding name which is `LISTEN.moe`